### PR TITLE
wasm-bindgen install missing from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ A Rust/WebAssembly 'learning by doing' example.
 
 ## Development setup
 
-Install Rust compiler target `wasm32-unknown-unknown`:
+Install Rust compiler target `wasm32-unknown-unknown` and `wasm-bindgen`:
 
 ```
 $ rustup target add wasm32-unknown-unknown
+$ cargo install wasm-bindgen-cli
 ```
 
 Install JS dependencies:


### PR DESCRIPTION
I get 
```
   Finished dev [unoptimized + debuginfo] target(s) in 1m 20s
+ wasm-bindgen ./target/wasm32-unknown-unknown/debug/wasm_tetris.wasm --out-dir ./wasm
./build.sh: line 7: wasm-bindgen: command not found
```